### PR TITLE
fix rayout collapse

### DIFF
--- a/template.go
+++ b/template.go
@@ -75,7 +75,7 @@ body{padding:15px;color:#333;word-break:break-all}
 .row:first-child > div{width:20%}
 .row:last-child > div{width:50%}
 .col{display:flex;flex-direction:column}
-.col > div{height:50%}
+.col > div{flex: 1 0 100px}
 .content{padding:10px;border-right:2px solid #666;border-bottom:2px solid #666}
 </style>
 {{ end }}`

--- a/watch.go
+++ b/watch.go
@@ -59,11 +59,7 @@ func runWatch(args []string) int {
 		return 1
 	}
 
-	lr, err := lrserver.New(lrserver.DefaultName, uint16(watchFlags.live))
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
-	}
+	lr := lrserver.New(lrserver.DefaultName, uint16(watchFlags.live))
 
 	lr.SetStatusLog(nil)
 	lr.SetErrorLog(nil)


### PR DESCRIPTION
Fixed rayout collapse at many texts written in SOLUTION, KEY METRICS, UNFAIR ADVANTAGE or CHANNELS. (includes #17) 

SOLUTION, KEY METRICS, UNFAIR ADVANTAGE, CHANNELSに書きすぎるとテキストが枠をはみ出してしまう問題を直しました。 